### PR TITLE
make labels visible

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,7 @@
             required
             disabled
           />
-          <label for="fullName" class="sr-only">Full Name</label>
+          <label for="fullName">Full Name</label>
           <input
             type="text"
             id="fullName"
@@ -128,15 +128,15 @@
             placeholder="Katumba John"
             required
           />
-          <label for="title" class="sr-only">Title</label>
+          <label for="title">Title</label>
           <input
             type="text"
             id="title"
             class="form-control"
-            placeholder="SMAU Member"
+            placeholder="e.g SMAU Member"
             required
           />
-          <label for="division" class="sr-only">Division</label>
+          <label for="division">Division</label>
           <input
             type="text"
             id="division"
@@ -144,7 +144,7 @@
             placeholder="division"
             required
           />
-          <label for="district" class="sr-only">District</label>
+          <label for="district">District</label>
           <input
             type="text"
             id="district"
@@ -152,7 +152,7 @@
             placeholder="district"
             required
           />
-          <label for="region" class="sr-only">Region</label>
+          <label for="region">Region</label>
           <input
             type="text"
             id="region"


### PR DESCRIPTION
This PR is making labels visible instead of considering only screen readers. Some members found it hard to know what some fields were representing. For example `SMAU Member` placeholder represents the title but it wasn't obvious for some members.

**Before**
![Screenshot_2020-12-24_16-43-24](https://user-images.githubusercontent.com/21334508/103092117-4453f380-4607-11eb-922d-5b3bd2db08bb.png)

**After**
![Screenshot_2020-12-24_16-43-38](https://user-images.githubusercontent.com/21334508/103092134-52097900-4607-11eb-9c7e-e25faa7f1f4d.png)
